### PR TITLE
chore: update release workflow to remove publish:ci command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build packages and run tests before publishing
+        run: npm run prepublish:ci
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: npm run publish:ci
+          publish: npm run release
           version: npm run version
           commit: 'chore: version packages'
           title: 'chore: version packages'

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "version": "changeset version",
     "release": "changeset publish",
     "prepublish:ci": "npm run build && npm run test",
-    "publish:ci": "npm run prepublish:ci && npm run release",
     "setup:git-template": "./scripts/setup-git-template.sh",
     "lint-staged": "lint-staged",
     "prepare": "husky || npm run setup:git-template || true"


### PR DESCRIPTION
- Removed the publish:ci command from package.json.
- Updated the release workflow to directly call the release command after prepublish steps.