### PR TITLE
Update CI and release workflows: restrict Node.js version to 22.x and…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.x]
 
     steps:
       - name: Checkout code
@@ -32,7 +32,7 @@ jobs:
         run: npm run build
         # Build tokens first (no dependencies), then dsm (depends on tokens)
         # This ensures type definitions are available for ESLint type checking
-      
+
       - name: Check build artifacts
         run: |
           test -d packages/tokens/build || exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Build packages and run tests before publishing
         run: npm run prepublish:ci
 
+      # Clear the auto-generated npm token placeholder to force npm to use
+      # GitHub's OIDC id-token for Trusted Publishing instead of an API secret.
+      - name: Fix npmrc for OIDC trusted publishing
+        run: |
+          sed -i '/_authToken/d' "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}" || true
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write
-      id-token: write # REQUIRED for trusted publishing
+      id-token: write # REQUIRED: Grants GitHub permission to request the OIDC token
       pull-requests: write
     env:
-      NPM_CONFIG_PROVENANCE: true # adds provenance to build
+      NPM_CONFIG_PROVENANCE: true # Cryptographically links the npm package to this exact GitHub run
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,20 +31,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'npm'
+          cache: 'npm' # Note: registry-url is omitted to prevent .npmrc credential conflicts with OIDC
 
       - name: Install dependencies
         run: npm ci
 
       - name: Build packages and run tests before publishing
         run: npm run prepublish:ci
-
-      # Clear the auto-generated npm token placeholder to force npm to use
-      # GitHub's OIDC id-token for Trusted Publishing instead of an API secret.
-      - name: Fix npmrc for OIDC trusted publishing
-        run: |
-          sed -i '/_authToken/d' "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}" || true
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
… adjust npmrc for OIDC trusted publishing